### PR TITLE
Use brew branch until issues resolved, enable otr

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Profanity < Formula
-  head 'https://github.com/boothj5/profanity.git', :using => :git  
+  head 'https://github.com/boothj5/profanity.git', :branch => "brew", :using => :git
 
   homepage 'https://github.com/boothj5/profanity'
 
@@ -15,6 +15,7 @@ class Profanity < Formula
   depends_on 'expat'
   depends_on 'libstrophe'
   depends_on 'ncurses'
+  depends_on 'libotr'
 
 
 
@@ -27,7 +28,7 @@ class Profanity < Formula
         ENV.append 'curl_LIBS', "-L#{HOMEBREW_PREFIX}/opt/curl/lib"
         ENV.append 'curl_CFLAGS',"-I#{HOMEBREW_PREFIX}/opt/curl/include"
         system "./bootstrap.sh"
-        system "./configure"
+        system "./configure --enable-otr"
         system "make", "PREFIX=#{prefix}", "install"
     end
 


### PR DESCRIPTION
The "brew" branch of profanity has some changes/hacks to make the brew formula work, so this is a temporary measure until I can figure out how to get some better solutions in master. I'll make sure the branch is updated as fixes/features go into master.

I've tested on my new Mac Mini and it seems to build no problem.

I've also added libotr as a dependency and tested and it seems to work fine.  The `--enable-otr` parameter to `./configure` is required to build with it.

With this patch, Mac users should hopefully now be able to build easily, and have all the features everyone else has!

The plan is to find better solutions to some of the hacks before release of 0.4.0.  Let me know if you have any comments/issues with the request.

Thanks,

James.
