### PR TITLE
Fix cached_location, new repo and dependency for libstrophe.

### DIFF
--- a/libstrophe.rb
+++ b/libstrophe.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libstrophe < Formula
-  head 'https://github.com/metajack/libstrophe.git', :using => :git
+  head 'https://github.com/strophe/libstrophe.git', :using => :git
 
   homepage 'http://strophe.im/libstrophe'
 

--- a/libstrophe.rb
+++ b/libstrophe.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libstrophe < Formula
-  head 'https://github.com/metajack/libstrophe.git', :using => :git  
+  head 'https://github.com/metajack/libstrophe.git', :using => :git
 
   homepage 'http://strophe.im/libstrophe'
 
@@ -10,6 +10,7 @@ class Libstrophe < Formula
   depends_on 'libtool' => :build
   depends_on 'pkg-config' => :build
   depends_on 'expat' => :build
+  depends_on 'check' => :build
 
 
 
@@ -32,7 +33,7 @@ class Libstrophe < Formula
   end
 
   def git_cache
-    @downloader.cached_location
+    @active_spec.downloader.cached_location
   end
 
 end

--- a/profanity.rb
+++ b/profanity.rb
@@ -45,7 +45,7 @@ class Profanity < Formula
   end
 
   def git_cache
-    @downloader.cached_location
+    @active_spec.downloader.cached_location
   end
 
 end


### PR DESCRIPTION
I kept getting this error when trying to use this formula:

``` ruby
Error: undefined method `cached_location' for nil:NilClass
```

While trying to debug the install I noticed that the repo for libstrophe changed and a dependency on `check` was added.  After making these changes everything worked.  

This pull request incorporates all of the changes I had to make.

Thanks for the formula!
