### PR TITLE
Added terminal-notifier dependency

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -16,6 +16,7 @@ class Profanity < Formula
   depends_on 'libstrophe'
   depends_on 'ncurses'
   depends_on 'libotr'
+  depends_on 'terminal-notifier'
 
 
   def install
@@ -29,6 +30,7 @@ class Profanity < Formula
         ENV.append 'curl_LIBS', "-L#{HOMEBREW_PREFIX}/opt/curl/lib"
         ENV.append 'curl_CFLAGS',"-I#{HOMEBREW_PREFIX}/opt/curl/include"
         system "./bootstrap.sh"
+        system "echo $PATH"
         system "./configure --enable-otr"
         system "make", "PREFIX=#{prefix}", "install"
     end

--- a/profanity.rb
+++ b/profanity.rb
@@ -30,7 +30,6 @@ class Profanity < Formula
         ENV.append 'curl_LIBS', "-L#{HOMEBREW_PREFIX}/opt/curl/lib"
         ENV.append 'curl_CFLAGS',"-I#{HOMEBREW_PREFIX}/opt/curl/include"
         system "./bootstrap.sh"
-        system "echo $PATH"
         system "./configure --enable-otr"
         system "make", "PREFIX=#{prefix}", "install"
     end


### PR DESCRIPTION
I've added code (in master and the brew branch) to enable desktop notification on OSX using terminal-notifier, and tested against my fork of the formula.

Let me know if you have any issues.

Thanks,

James. 

Edit: If you want to test the notifications, they need to be enabled in profanity with the `/notify` command. see `/help notify`.
