### PR TITLE
Changes to work with profanity master branch.

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Profanity < Formula
-  head 'https://github.com/boothj5/profanity.git', :branch => "brew", :using => :git
+  head 'https://github.com/boothj5/profanity.git', :using => :git
 
   homepage 'https://github.com/boothj5/profanity'
 
@@ -29,8 +29,9 @@ class Profanity < Formula
         ENV.append 'ncurses_CFLAGS',"-I#{HOMEBREW_PREFIX}/opt/ncurses/include"
         ENV.append 'curl_LIBS', "-L#{HOMEBREW_PREFIX}/opt/curl/lib"
         ENV.append 'curl_CFLAGS',"-I#{HOMEBREW_PREFIX}/opt/curl/include"
+        system "cp -r #{git_cache}/.git .git"
         system "./bootstrap.sh"
-        system "./configure --enable-otr"
+        system "./configure"
         system "make", "PREFIX=#{prefix}", "install"
     end
 


### PR DESCRIPTION
I've now got profanity master branch working with brew, and made the following changes to the formula:
- Copy .git, required to compile version information.
- Remove --enable-otr flag, now included by default.
- Remove branch from head command.

If you're happy with the changes, I'll remove the brew branch once you've pulled them.

Thanks,

James.
