### PR TITLE
Removed gnutls dependency, added autoconf-archive and libgcrypt

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -6,6 +6,7 @@ class Profanity < Formula
   homepage 'https://github.com/boothj5/profanity'
 
   depends_on 'autoconf' => :build
+  depends_on 'autoconf-archive' => :build
   depends_on 'automake' => :build
   depends_on 'libtool' => :build
   depends_on 'openssl' => :build
@@ -17,7 +18,7 @@ class Profanity < Formula
   depends_on 'ncurses'
   depends_on 'libotr'
   depends_on 'terminal-notifier'
-  depends_on 'gnutls'
+  depends_on 'libgcrypt'
 
 
   def install


### PR DESCRIPTION
GnuTLS has been replaced with the simpler libgcrypt library, and autoconf-archives added which makes configuring for libgcrypt easier.

Let me know if you find any issues.
