### PR TITLE
Removed autoconf-archive and libgcrypt dependencies

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -6,7 +6,6 @@ class Profanity < Formula
   homepage 'https://github.com/boothj5/profanity'
 
   depends_on 'autoconf' => :build
-  depends_on 'autoconf-archive' => :build
   depends_on 'automake' => :build
   depends_on 'libtool' => :build
   depends_on 'openssl' => :build
@@ -18,7 +17,6 @@ class Profanity < Formula
   depends_on 'ncurses'
   depends_on 'libotr'
   depends_on 'terminal-notifier'
-  depends_on 'libgcrypt'
 
 
   def install


### PR DESCRIPTION
The code now includes a public domain SHA1 hashing algorithm, so these dependencies are no longer required.

Thanks,

James.
