### PR TITLE
Broken install in homebrew 0.9.5

### DIFF
--- a/libstrophe.rb
+++ b/libstrophe.rb
@@ -33,7 +33,7 @@ class Libstrophe < Formula
   end
 
   def git_cache
-    @active_spec.downloader.cached_location
+    cached_download
   end
 
 end

--- a/profanity.rb
+++ b/profanity.rb
@@ -46,7 +46,7 @@ class Profanity < Formula
   end
 
   def git_cache
-    @active_spec.downloader.cached_location
+    cached_download
   end
 
 end


### PR DESCRIPTION
Install was failing in Homebrew 0.9.5 due to a missing method/property. Adjusted it to point to the correct method directly in the Formula class
